### PR TITLE
Adds PartialLogout as a valid logout response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules
 # Users Environment Variables
 .lock-wscript
 
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -258,8 +258,12 @@ module.exports = function (options) {
         return next(e);
       }
 
-      // validate status
-      if (parsedResponse.status !== 'urn:oasis:names:tc:SAML:2.0:status:Success') {
+      // validate statuses
+      const validStatuses = [
+        'urn:oasis:names:tc:SAML:2.0:status:Success', 
+        'urn:oasis:names:tc:SAML:2.0:status:PartialLogout'
+      ];
+      if (!validStatuses.includes(parsedResponse.status)) {
         var err_message = parsedResponse.message && parsedResponse.detail ?
           util.format('%s (%s)', parsedResponse.message, parsedResponse.detail) :
           parsedResponse.message ||

--- a/test/response_post.tests.js
+++ b/test/response_post.tests.js
@@ -46,6 +46,21 @@ describe('SAMLResponse - HTTP POST Binding', function () {
           done();
         });
       });
+
+      it('should call next and set parsed SAMLResponse for a PartialLogout response', function (done) {
+        var req = {
+          query: {},
+          body: { SAMLResponse: signAndBase64(util.format(template, '<samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:PartialLogout" /></samlp:Status>')) }
+        };
+
+        logout(req, {}, function (err) {
+          expect(err).to.be.undefined;
+          expect(req.parsedSAMLResponse).to.be.ok;
+          expect(Object.keys(req.parsedSAMLResponse)).to.have.length(1);
+          expect(req.parsedSAMLResponse.status).to.equal('urn:oasis:names:tc:SAML:2.0:status:PartialLogout');
+          done();
+        });
+      });
     });
 
     describe('when status is invalid', function () {
@@ -195,6 +210,21 @@ describe('SAMLResponse - HTTP POST Binding', function () {
           expect(req.parsedSAMLResponse).to.be.ok;
           expect(Object.keys(req.parsedSAMLResponse)).to.have.length(1);
           expect(req.parsedSAMLResponse.status).to.equal('urn:oasis:names:tc:SAML:2.0:status:Success');
+          done();
+        });
+      });
+
+      it('should call next and set parsed SAMLResponse for a PartialLogout response', function (done) {
+        var req = {
+          query: {},
+          body: { SAMLResponse: base64(util.format(template, '<samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:PartialLogout" /></samlp:Status>')) }
+        };
+
+        logout(req, {}, function (err) {
+          expect(err).to.be.undefined;
+          expect(req.parsedSAMLResponse).to.be.ok;
+          expect(Object.keys(req.parsedSAMLResponse)).to.have.length(1);
+          expect(req.parsedSAMLResponse.status).to.equal('urn:oasis:names:tc:SAML:2.0:status:PartialLogout');
           done();
         });
       });

--- a/test/response_redirect.tests.js
+++ b/test/response_redirect.tests.js
@@ -71,6 +71,25 @@ describe('SAMLResponse - HTTP Redirect Binding', function () {
             done();
           });
         });
+
+        it('should call next and set parsed SAMLResponse for a PartialLogout response', function (done) {
+          var query = deflateAndBase64AndSign({
+            SAMLResponse: util.format(template, '<samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:PartialLogout" /></samlp:Status>')
+          });
+
+          var req = {
+            url: 'https://foo.com?' + qs.stringify(query),
+            query: query
+          };
+
+          logout(req, {}, function (err) {
+            expect(err).to.be.undefined;
+            expect(req.parsedSAMLResponse).to.be.ok;
+            expect(Object.keys(req.parsedSAMLResponse)).to.have.length(1);
+            expect(req.parsedSAMLResponse.status).to.equal('urn:oasis:names:tc:SAML:2.0:status:PartialLogout');
+            done();
+          });
+        });
       });
 
       it('should call next and set parsed SAMLResponse when raw query does not match unescaped query', function (done) {
@@ -292,6 +311,25 @@ describe('SAMLResponse - HTTP Redirect Binding', function () {
             expect(req.parsedSAMLResponse).to.be.ok;
             expect(Object.keys(req.parsedSAMLResponse)).to.have.length(1);
             expect(req.parsedSAMLResponse.status).to.equal('urn:oasis:names:tc:SAML:2.0:status:Success');
+            done();
+          });
+        });
+
+        it('should call next and set parsed SAMLResponse for a PartialLogout response', function (done) {
+          var query = signAndBase64({
+            SAMLResponse: util.format(template, '<samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:PartialLogout" /></samlp:Status>')
+          });
+
+          var req = {
+            url: 'https://foo.com?' + qs.stringify(query),
+            query: query
+          };
+
+          logout(req, {}, function (err) {
+            expect(err).to.be.undefined;
+            expect(req.parsedSAMLResponse).to.be.ok;
+            expect(Object.keys(req.parsedSAMLResponse)).to.have.length(1);
+            expect(req.parsedSAMLResponse.status).to.equal('urn:oasis:names:tc:SAML:2.0:status:PartialLogout');
             done();
           });
         });


### PR DESCRIPTION
### Description

Add the `urn:oasis:names:tc:SAML:2.0:status:PartialLogout` as a valid logout response.

### Testing

- [x ] This change adds test coverage for new/changed/fixed functionality