### PR TITLE
Fix bias in ID generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Test execution
+      run: npm run cover

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Federated single sign-out for SAMLP providers from express.js applications.
 
+![Build Status](https://github.com/auth0/samlp-logout/workflows/Tests/badge.svg)
+
 ## Installation
 
 ```

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,16 +1,21 @@
-var url = require('url');
-var xtend = require('xtend');
+const url = require('url');
+const xtend = require('xtend');
 
 const IdGenerator = require('auth0-id-generator');
-const generator = new IdGenerator({len: 20, alphabet:"abcdef0123456789"});
+const generator = new IdGenerator({len: 20, alphabet: "abcdef0123456789"});
 
-exports.generateUniqueID = function(){
+/**
+ * Generates a random alphanumeric ID.
+ * > IDs are 20 characters long and use the hexadecimal alphabet
+ * @returns {string}
+ */
+exports.generateUniqueID = function () {
   return generator.get();
 };
 
 exports.getRoundTripDateFormat = function() {
   //http://msdn.microsoft.com/en-us/library/az4se3k1.aspx#Roundtrip
-  var date = new Date();
+  const date = new Date();
   return date.getUTCFullYear() + '-' +
         ('0' + (date.getUTCMonth()+1)).slice(-2) + '-' +
         ('0' + date.getUTCDate()).slice(-2) + 'T' +
@@ -20,7 +25,7 @@ exports.getRoundTripDateFormat = function() {
 };
 
 exports.appendQueryString = function(initialUrl, query) {
-  var parsed = url.parse(initialUrl, true);
+  const parsed = url.parse(initialUrl, true);
   parsed.query = xtend(parsed.query, query);
   delete parsed.search;
   return url.format(parsed);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,14 +1,11 @@
 var url = require('url');
 var xtend = require('xtend');
 
-exports.generateUniqueID = function(){
-  var chars = 'abcdef0123456789';
-  var uniqueID = '';
-  for (var i = 0; i < 20; i++) {
-    uniqueID += chars.substr(Math.floor((Math.random()*15)), 1);
-  }
+const IdGenerator = require('auth0-id-generator');
+const generator = new IdGenerator({len: 20, alphabet:"abcdef0123456789"});
 
-  return uniqueID;
+exports.generateUniqueID = function(){
+  return generator.get();
 };
 
 exports.getRoundTripDateFormat = function() {

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "description": "Federated SAMLP single sign-out",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "./node_modules/.bin/_mocha -R spec --colors"
   },
   "author": "",
   "license": "MIT",
   "dependencies": {
     "@auth0/thumbprint": "0.0.6",
+    "auth0-id-generator": "^0.2.0",
     "ejs": "^2.5.6",
     "xml-crypto": "~0.10.1",
     "xmldom": "^0.1.19",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Federated SAMLP single sign-out",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/_mocha -R spec --colors"
+    "test": "./node_modules/.bin/_mocha -R spec --colors",
+    "cover": "nyc npm run test"
   },
   "repository": {
     "type": "git",
@@ -24,7 +25,9 @@
   "devDependencies": {
     "chai": "^1.9.1",
     "cheerio": "^0.22.0",
-    "mocha": "^8.2.1"
+    "mocha": "^8.2.1",
+    "nyc": "^15.1.0",
+    "standard-version": "^9.1.0"
   },
   "keywords": [
     "saml",

--- a/package.json
+++ b/package.json
@@ -6,21 +6,25 @@
   "scripts": {
     "test": "./node_modules/.bin/_mocha -R spec --colors"
   },
-  "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/auth0/samlp-logout.git"
+  },
+  "author": "Auth0",
   "license": "MIT",
   "dependencies": {
     "@auth0/thumbprint": "0.0.6",
     "auth0-id-generator": "^0.2.0",
     "ejs": "^2.5.6",
-    "xml-crypto": "~0.10.1",
+    "xml-crypto": "^2.0.0",
     "xmldom": "^0.1.19",
     "xpath": "0.0.21",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",
-    "mocha": "^1.20.1",
-    "cheerio": "^0.19.0"
+    "cheerio": "^0.22.0",
+    "mocha": "^8.2.1"
   },
   "keywords": [
     "saml",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "https://github.com/auth0/samlp-logout.git"
   },
+  "bugs": {
+    "url": "https://github.com/auth0/samlp-logout/issues"
+  },
   "author": "Auth0",
   "license": "MIT",
   "dependencies": {

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -1,0 +1,16 @@
+const expect = require('chai').expect;
+
+const utils = require('../lib/utils');
+
+describe('utils', function () {
+    describe('generateUniqueID', function() {
+        it('should generate an ID 20 chars long', function() {
+            expect(utils.generateUniqueID().length).to.equal(20);
+        });
+    });
+    describe('generateUniqueID', function() {
+        it('should generate an ID from the alphabet', function() {
+            expect('abcdef0123456789'.split('')).to.include.members(utils.generateUniqueID().split(''));
+        });
+    });
+});


### PR DESCRIPTION
### Description

The existing ID generation is not cryptographically secure - this PR introduces the id-generation library for Request and Response generation.

Also as part of the update, the following changes have been made:

- Added id-generation lib for id creation.  Updated utils.js (https://github.com/auth0/samlp-logout/pull/14/files#diff-5dfe38baf287dcf756a17c2dd63483781b53bf4b669e10efdd01e74bcd8e780a) and utils.tests.js ( https://github.com/auth0/samlp-logout/pull/14/files#diff-bf6546509a810a43d03948d39e0eec245309cdeb79383531dd5e49fb22151e62). 
  - Includes minor utils.js v -> const/let refactor
- Rectified multiple NPM vulnerabilities 
  - **xml-crypto** (0.10.1 -> 2.0.0) This version removes support for HMAC by default, which is unsupported by this library but also introduces fixes and changes to Exclusive XML Canonicalization  - diff: https://github.com/yaronn/xml-crypto/compare/v1.0.0...v2.0.0 - security fix
    - **express** (3.11.0 -> 4.17.1) Major release that changes API footprint - security fix, removes support for node <v10
    - **mocha** (1.8.1 -> 8.2.1) Major release that changes API footprint - security fix, removes support for node <v10
    - **cheerio** (0.19.0 -> 0.22.0)
- Fixed non-running test suite : https://github.com/auth0/samlp-logout/pull/14/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R7
- Introduced NYC code coverage tool 
- Introduced standard-version library for release management
- Added GI Action-based CI (https://github.com/auth0/samlp-logout/pull/14/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f)
- Added missing package.json information.

### References

Introduces changes from:
https://github.com/auth0/samlp-logout/pull/8
https://github.com/auth0/samlp-logout/pull/5

### Testing

Tests for ID generation have been added - ensuring length and dictionary membership.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] ~~I have added documentation for new/changed functionality in this PR or in auth0.com/docs~~
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
