### PR TITLE
fix: ulp-3026: fix logout for misbehaving Azure AD.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.1.0](https://github.com/auth0/samlp-logout/compare/v3.0.0...v3.1.0) (2021-08-30)
+- Do not send empty RelayState fields. This works around a bug in Azure AD.
+
 ## [3.0.0](https://github.com/auth0/samlp-logout/compare/v2.3.3...v3.0.0) (2021-02-09)
 
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "samlp-logout",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Federated SAMLP single sign-out",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/_mocha -R spec --colors",
+    "test-debug": "mocha --inspect-brk -R spec --colors",
     "cover": "nyc npm run test",
     "release": "standard-version"
   },

--- a/templates/Form.ejs
+++ b/templates/Form.ejs
@@ -7,7 +7,9 @@
         <input type="hidden" 
                name="<%= type %>" 
                value="<%= token %>">
-        <input type="hidden" name="RelayState" value="<%= RelayState %>">
+        <% if(typeof RelayState !== 'undefined') { %>
+            <input type="hidden" name="RelayState" value="<%= RelayState %>">
+        <% } %>
         <noscript>
             <p>
                 Script is disabled. Click Submit to continue.

--- a/test/request_post.tests.js
+++ b/test/request_post.tests.js
@@ -11,116 +11,163 @@ var credentials = {
   key:  fs.readFileSync(path.join(__dirname, 'fixture', 'samlp.test-cert.key')),
 };
 
-describe('SAMLRequest - HTTP POST Binding', function () {
-  var callback, RelayState, SAMLRequest, contentType;
+describe('SAMLRequest - HTTP POST Binding', function () {  
+  describe('common use cases', function() {
+    var callback, RelayState, SAMLRequest, contentType;
 
-  before(function (done) {
-    var logout = samlpLogout({
-      protocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-      issuer: 'http://example.org',
-      identityProviderUrl: 'http://myadfs.com?a=b',
-      cert: credentials.cert,
-      key: credentials.key,
-      relayState: 'foo=bar',
-      identityProviderSigningCert: credentials.cert, // only for testing purposes
-    });
+    before(function (done) {
+      var logout = samlpLogout({
+        protocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        issuer: 'http://example.org',
+        identityProviderUrl: 'http://myadfs.com?a=b',
+        cert: credentials.cert,
+        key: credentials.key,
+        relayState: 'foo=bar',
+        identityProviderSigningCert: credentials.cert, // only for testing purposes
+      });
 
-    logout({
-      samlNameID: '112233',
-      samlSessionIndex: '554433',
-      query: {},
-      body: {}
-    }, {
-      send: function (html) {
-        var $ = cheerio.load(html);
+      logout({
+        samlNameID: '112233',
+        samlSessionIndex: '554433',
+        query: {},
+        body: {}
+      }, {
+        send: function (html) {
+          var $ = cheerio.load(html);
 
-        callback = $('form').attr('action');
-        RelayState = $('form input[name="RelayState"]').val();
-        var samlRequestInput = $('form input[name="SAMLRequest"]').val();
+          callback = $('form').attr('action');
+          RelayState = $('form input[name="RelayState"]').val();
+          var samlRequestInput = $('form input[name="SAMLRequest"]').val();
 
-        var SAMLRequestStr = new Buffer(samlRequestInput, 'base64').toString();
-        SAMLRequest = new DOMParser().parseFromString(SAMLRequestStr);
-        done();
-      },
-      set: function (key, value) {
-        if (key === 'Content-Type') {
-          contentType = value;
+          var SAMLRequestStr = Buffer.from(samlRequestInput, 'base64').toString();
+          SAMLRequest = new DOMParser().parseFromString(SAMLRequestStr);
+          done();
+        },
+        set: function (key, value) {
+          if (key === 'Content-Type') {
+            contentType = value;
+          }
         }
-      }
+      });
+    });
+
+    it('should set Content-Type', function () {
+      expect(contentType)
+        .to.equal('text/html');
+    });
+
+    it('should include callback', function () {
+      expect(callback)
+        .to.equal('http://myadfs.com?a=b');
+    });
+
+    it('should include RelayState', function () {
+      expect(RelayState)
+        .to.equal('foo=bar');
+    });
+
+    it('should be a samlp:LogoutRequest doc', function () {
+      expect(SAMLRequest.firstChild.nodeName)
+        .to.equal('samlp:LogoutRequest');
+    });
+
+    it('should contain an ID attribute', function () {
+      expect(SAMLRequest.firstChild.hasAttribute('ID'))
+        .to.be.ok;
+    });
+
+    it('should contain an IssueInstant attribute', function () {
+      expect(SAMLRequest.firstChild.hasAttribute('IssueInstant'))
+        .to.be.ok;
+    });
+
+    it('should contain a valid signature embedded', function () {
+      var signature = xmlCrypto.xpath(SAMLRequest, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
+      var sig = new xmlCrypto.SignedXml();
+      sig.keyInfoProvider = {
+        getKeyInfo: function () {
+          return '<X509Data></X509Data>';
+        },
+        getKey: function () {
+          return credentials.cert;
+        }
+      };
+
+      sig.loadSignature(signature.toString());
+      expect(sig.checkSignature(SAMLRequest.toString())).to.be.true;
+      expect(sig.validationErrors).to.be.empty;
+
+      expect(SAMLRequest.documentElement
+            .getElementsByTagName('SignatureMethod')[0]
+            .getAttribute('Algorithm')).to.equal('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256');
+
+      expect(SAMLRequest.documentElement
+            .getElementsByTagName('DigestMethod')[0]
+            .getAttribute('Algorithm')).to.equal('http://www.w3.org/2001/04/xmlenc#sha256');
+    });
+
+    it('should contain the issuer element', function () {
+      var el = SAMLRequest.childNodes[0]
+                          .getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'Issuer')[0];
+      expect(el.childNodes[0].textContent).to.equal('http://example.org');
+    });
+
+    it('should contain the nameid', function () {
+      var el = SAMLRequest.childNodes[0]
+                          .getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'NameID')[0];
+      expect(el.childNodes[0].textContent).to.equal('112233');
+    });
+
+
+    it('should contain the sessionindex', function () {
+      var el = SAMLRequest.childNodes[0]
+                          .getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:protocol', 'SessionIndex')[0];
+      expect(el.childNodes[0].textContent).to.equal('554433');
     });
   });
 
-  it('should set Content-Type', function () {
-    expect(contentType)
-      .to.equal('text/html');
-  });
+  describe('corner cases', function() {
+    describe('no RelayState', function(){
+      var callback, RelayState, SAMLRequest, contentType;
 
-  it('should include callback', function () {
-    expect(callback)
-      .to.equal('http://myadfs.com?a=b');
-  });
+      before(function (done) {
+        var logout = samlpLogout({
+          protocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+          issuer: 'http://example.org',
+          identityProviderUrl: 'http://myadfs.com?a=b',
+          cert: credentials.cert,
+          key: credentials.key,
+          identityProviderSigningCert: credentials.cert, // only for testing purposes
+        });
+  
+        logout({
+          samlNameID: '112233',
+          samlSessionIndex: '554433',
+          query: {},
+          body: {}
+        }, {
+          send: function (html) {
+            var $ = cheerio.load(html);
+  
+            callback = $('form').attr('action');
+            RelayState = $('form input[name="RelayState"]').val();
+            var samlRequestInput = $('form input[name="SAMLRequest"]').val();
+  
+            var SAMLRequestStr = Buffer.from(samlRequestInput, 'base64').toString();
+            SAMLRequest = new DOMParser().parseFromString(SAMLRequestStr);
+            done();
+          },
+          set: function (key, value) {
+            if (key === 'Content-Type') {
+              contentType = value;
+            }
+          }
+        });
+      });
 
-  it('should include RelayState', function () {
-    expect(RelayState)
-      .to.equal('foo=bar');
-  });
-
-  it('should be a samlp:LogoutRequest doc', function () {
-    expect(SAMLRequest.firstChild.nodeName)
-      .to.equal('samlp:LogoutRequest');
-  });
-
-  it('should contain an ID attribute', function () {
-    expect(SAMLRequest.firstChild.hasAttribute('ID'))
-      .to.be.ok;
-  });
-
-  it('should contain an IssueInstant attribute', function () {
-    expect(SAMLRequest.firstChild.hasAttribute('IssueInstant'))
-      .to.be.ok;
-  });
-
-  it('should contain a valid signature embedded', function () {
-    var signature = xmlCrypto.xpath(SAMLRequest, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
-    var sig = new xmlCrypto.SignedXml();
-    sig.keyInfoProvider = {
-      getKeyInfo: function () {
-        return '<X509Data></X509Data>';
-      },
-      getKey: function () {
-        return credentials.cert;
-      }
-    };
-
-    sig.loadSignature(signature.toString());
-    expect(sig.checkSignature(SAMLRequest.toString())).to.be.true;
-    expect(sig.validationErrors).to.be.empty;
-
-    expect(SAMLRequest.documentElement
-          .getElementsByTagName('SignatureMethod')[0]
-          .getAttribute('Algorithm')).to.equal('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256');
-
-    expect(SAMLRequest.documentElement
-          .getElementsByTagName('DigestMethod')[0]
-          .getAttribute('Algorithm')).to.equal('http://www.w3.org/2001/04/xmlenc#sha256');
-  });
-
-  it('should contain the issuer element', function () {
-    var el = SAMLRequest.childNodes[0]
-                        .getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'Issuer')[0];
-    expect(el.childNodes[0].textContent).to.equal('http://example.org');
-  });
-
-  it('should contain the nameid', function () {
-    var el = SAMLRequest.childNodes[0]
-                        .getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'NameID')[0];
-    expect(el.childNodes[0].textContent).to.equal('112233');
-  });
-
-
-  it('should contain the sessionindex', function () {
-    var el = SAMLRequest.childNodes[0]
-                        .getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:protocol', 'SessionIndex')[0];
-    expect(el.childNodes[0].textContent).to.equal('554433');
+      it('should not include RelayState', function () {
+        expect(RelayState).to.be.undefined;
+      });
+    });
   });
 });


### PR DESCRIPTION
### Description
Azure AD includes empty RelayState in the signature computation even when SAML says it should not: https://www.oasis-open.org/committees/download.php/35387/sstc-saml-bindings-errata-2.0-wd-05-diff.pdf Avoid sending RelayState when it is empty.

### References
- ULP-3026
- ESD-12841

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
