### PR TITLE
fix!: callback chain stopped when using HTTP-POST bindings

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,9 +60,9 @@ function prepareAndSendToken (req, res, type, token, options, cb) {
     }
 
     params[type] = new Buffer(token).toString('base64');
-    send(params);
+    const sendResult = send(params);
     cb();
-    return;
+    return sendResult;
   }
 
   // Default: HTTP-Redirect with deflate encoding (http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf - section 3.4.4.1)

--- a/index.js
+++ b/index.js
@@ -60,7 +60,9 @@ function prepareAndSendToken (req, res, type, token, options, cb) {
     }
 
     params[type] = new Buffer(token).toString('base64');
-    return send(params);
+    send(params);
+    cb();
+    return;
   }
 
   // Default: HTTP-Redirect with deflate encoding (http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf - section 3.4.4.1)
@@ -80,6 +82,7 @@ function prepareAndSendToken (req, res, type, token, options, cb) {
     }
 
     send(params);
+    cb();
   });
 }
 

--- a/test/idp_request_post.tests.js
+++ b/test/idp_request_post.tests.js
@@ -176,6 +176,8 @@ describe('IdP Initiated - SAMLRequest - HTTP POST Binding', function () {
 
     describe('when request is valid', function () {
       var callback, RelayState, SAMLResponse, contentType;
+      var nextCalled = false;
+      var next = () => { nextCalled = true; };
 
       before(function (done) {
         var req = {
@@ -204,7 +206,7 @@ describe('IdP Initiated - SAMLRequest - HTTP POST Binding', function () {
           }
         };
 
-        logout(req, res);
+        logout(req, res, next);
       });
 
       it('should set Content-Type', function () {
@@ -284,6 +286,10 @@ describe('IdP Initiated - SAMLRequest - HTTP POST Binding', function () {
           .getElementsByTagName('samlp:StatusCode')[0]
           .getAttribute('Value')).to.equal('urn:oasis:names:tc:SAML:2.0:status:Success');
       });
+
+      it ('should resume middleware chain', function () {
+        expect(nextCalled).to.equal(true);
+      })
     });
   });
 });

--- a/test/idp_request_redirect.tests.js
+++ b/test/idp_request_redirect.tests.js
@@ -170,6 +170,8 @@ describe('IdP Initiated - SAMLRequest - HTTP Redirect Binding', function () {
 
     describe('when request is valid', function () {
       var redirect, RelayState, SAMLResponse, SAMLResponseOriginal, SigAlg, Signature;
+      var nextCalled = false;
+      var next = () => { nextCalled = true; };
 
       before(function (done) {
         var query = deflateAndBase64AndSign({
@@ -196,7 +198,7 @@ describe('IdP Initiated - SAMLRequest - HTTP Redirect Binding', function () {
           }
         };
 
-        logout(req, res);
+        logout(req, res, next);
       });
 
       it('should redirect to idp endpoint', function () {
@@ -269,6 +271,10 @@ describe('IdP Initiated - SAMLRequest - HTTP Redirect Binding', function () {
           .getElementsByTagName('samlp:StatusCode')[0]
           .getAttribute('Value')).to.equal('urn:oasis:names:tc:SAML:2.0:status:Success');
       });
+
+      it ('should resume middleware chain', function () {
+        expect(nextCalled).to.equal(true);
+      })
     });
   });
 });

--- a/test/request_post.tests.js
+++ b/test/request_post.tests.js
@@ -48,7 +48,7 @@ describe('SAMLRequest - HTTP POST Binding', function () {
             contentType = value;
           }
         }
-      });
+      }, () => {});
     });
 
     it('should set Content-Type', function () {

--- a/test/request_redirect.tests.js
+++ b/test/request_redirect.tests.js
@@ -53,7 +53,7 @@ describe('SAMLRequest - HTTP Redirect Binding', function () {
             done();
           });
         }
-      });
+      }, () => {});
     });
 
     it('should include RelayState', function () {


### PR DESCRIPTION
BREAKING CHANGE

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Currently, the logout function does not resume the middleware chain with the provided callback after a response is successfully sent to the UA.

This PR aims to introduce the missing calls to the provided callback on success.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
